### PR TITLE
Add pico.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
       <li><a href="/meyer">meyer</a>
       <li><a href="/minicss">minicss</a>
       <li><a href="/no-class">no-class</a>
+      <li><a href="/pico.css">pico.css</a>
       <li><a href="/sakura">sakura</a>
       <li><a href="/sakura-vader">sakura-vader</a>
       <li><a href="/stylize.css">stylize.css</a>

--- a/pico.css/link.txt
+++ b/pico.css/link.txt
@@ -1,0 +1,1 @@
+https://picocss.com/

--- a/pico.css/snippet.txt
+++ b/pico.css/snippet.txt
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.classless.min.css" type="text/css">


### PR DESCRIPTION
A minimal CSS design system in pure semantic HTML with two themes (Light & Dark) automatically enabled according to user preference (`prefers-color-scheme`)

- Website: https://picocss.com/
- Repository: https://github.com/picocss/pico

Pico is [_classlight_](https://picocss.com/#principles) by default, but also has a [_classless_ version](https://picocss.com/docs/#classless).

CSS BED is linked in the [documentation](https://picocss.com/docs/) footer.

Thank you for your work.